### PR TITLE
104 make site not crash when no machine is in database (Presentation)

### DIFF
--- a/WebApplication/src/components/MachineList.js
+++ b/WebApplication/src/components/MachineList.js
@@ -17,16 +17,20 @@ export class MachineList extends Component {
         fetch('http://localhost:8080/api/machines')
         .then(response => response.json())
         .then(data => {
-            //Loops through and add all machines to the list of machines
-            data.forEach(element => {
-                this.setState({ machines: [...this.state.machines, {label: element.ip, value: element.id}] });
-            });
+            if (data.status === 200) {
+                //Loops through and add all machines to the list of machines
+                data.forEach(element => {
+                    this.setState({ machines: [...this.state.machines, {label: element.ip, value: element.id}] });
+                });
 
-            //Sets first machine as default as the list will have it selected initially
-            this.setState({selectedMachine: {
-                ip: this.state.machines[0].label,
-                id: this.state.machines[0].value
-            }})
+                //Sets first machine as default as the list will have it selected initially
+                if (this.state.machines.length !== 0) {
+                    this.setState({selectedMachine: {
+                        ip: this.state.machines[0].label,
+                        id: this.state.machines[0].value
+                    }})
+                }
+            }
         });
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>14</source>
-                    <target>14</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
+                    <source>15</source>
+                    <target>15</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #Datasource setup
 spring.datasource.url=jdbc:postgresql://localhost:5432/brewmes
 spring.datasource.username=postgres
-spring.datasource.password=#password 
+spring.datasource.password=0205
 
 #sql dialect for hibernate
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #Datasource setup
 spring.datasource.url=jdbc:postgresql://localhost:5432/brewmes
 spring.datasource.username=postgres
-spring.datasource.password=0205
+spring.datasource.password=#password
 
 #sql dialect for hibernate
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/brewmes/demo/BrewMESApplicationTests.java
+++ b/src/test/java/com/brewmes/demo/BrewMESApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class BrewMESApplicationTests {
+class BrewMesApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
Making the site not crash when list is empty or when the connection between database and backend is failing, causing a response with status code other than 200.

close #104 